### PR TITLE
storing inventory events

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ creds.json
 .DS_Store
 endicia_export_log.xml
 temp/*
+data/client_id.json

--- a/install.sh
+++ b/install.sh
@@ -61,6 +61,7 @@ apt-get -y install printer-driver-dymo
 pip install intelhex
 pip install crcmod
 pip install RPi.GPIO
+pip install --upgrade google-api-python-client
 
 # Clone ops_tools
 git clone git@github.com:The-Public-Radio/ops_tools.git /home/pi/ops_tools

--- a/install.sh
+++ b/install.sh
@@ -62,6 +62,9 @@ pip install intelhex
 pip install crcmod
 pip install RPi.GPIO
 pip install --upgrade google-api-python-client
+pip install apiclient
+pip install discovery
+pip install gspread
 
 # Clone ops_tools
 git clone git@github.com:The-Public-Radio/ops_tools.git /home/pi/ops_tools

--- a/inventory_event.py
+++ b/inventory_event.py
@@ -10,7 +10,7 @@
 
 
 import gspread
-import time
+import datetime
 import os
 import sys
 from oauth2client.service_account import ServiceAccountCredentials
@@ -39,7 +39,7 @@ if event not in events:
 	print 'Use `assemble` or `fulfill`.'
 	sys.exit(1)
 
-timestamp = time.time()
+timestamp = datetime.datetime.now().isoformat()
 print timestamp
 
 scope = ['https://spreadsheets.google.com/feeds']

--- a/inventory_event.py
+++ b/inventory_event.py
@@ -17,13 +17,9 @@ from oauth2client.service_account import ServiceAccountCredentials
 # Set username. Ideally the username is always set to be a person's name (or similar),
 # but in the cases where it's not set then the Raspberry Pi's $HOSTNAME will suffice.
 if (len(sys.argv) == 3):
-	print 'three'
 	username = sys.argv[2]
-	print username
 elif (len(sys.argv) == 2):
-	print 'two'
-	username = os.uname()[1]
-	print username
+	username = uname()[1]
 else:
 	print 'ERROR - wrong number of arguments.'
 	print 'Usage: $ inventory_event.py <event> <username>'
@@ -39,7 +35,7 @@ if event not in events:
 	sys.exit(1)
 
 timestamp = datetime.datetime.now().isoformat()
-print timestamp
+print 'time is' timestamp
 
 scope = ['https://spreadsheets.google.com/feeds']
 credentials = ServiceAccountCredentials.from_json_keyfile_name('/home/pi/tpr-inv.json', scope)

--- a/inventory_event.py
+++ b/inventory_event.py
@@ -72,7 +72,7 @@ def record_fulfill(user):
 
 def store_event(user):
 	f = open('/home/pi/ops_tools/data/stored_inventory_events.csv','w')
-	f.write(event','timestamp','user'\n')
+	f.write(event,timestamp,user'\n')
 	f.close()
 
 store_event(username)

--- a/inventory_event.py
+++ b/inventory_event.py
@@ -12,6 +12,7 @@
 import gspread
 import time
 import os
+import sys
 from oauth2client.service_account import ServiceAccountCredentials
 
 if (len(sys.argv) == '3'):

--- a/inventory_event.py
+++ b/inventory_event.py
@@ -48,12 +48,28 @@ c = gspread.authorize(credentials)
 spreadsheet = c.open('PR9450 Part Usage')
 
 
-def assemble(username):
+def assemble(user):
 	PCB = spreadsheet.worksheet("PR9027")
-	PCB.append_row(["radio_assemble", timestamp, username])
+	PCB.append_row(["radio_assemble", timestamp, "-1", user])
+	lid = spreadsheet.worksheet("PR1014")
+	lid.append_row(["radio_assemble", timestamp, "-1", user])
+	screw = spreadsheet.worksheet("PR2039")
+	screw.append_row(["radio_assemble", timestamp, "-4", user])	
+	knob = spreadsheet.worksheet("PR2036")
+	knob.append_row(["radio_assemble", timestamp, "-1", user])
+
+def fulfill(user):
+	antenna = spreadsheet.worksheet("PR2034")
+	antenna.append_row(["radio_assemble", timestamp, "-1", user])
+	box = spreadsheet.worksheet("PR2500")
+	box.append_row(["radio_assemble", timestamp, "-1", user])
+	jar = spreadsheet.worksheet("PR1016")
+	jar.append_row(["radio_assemble", timestamp, "-1", user])
 
 if (event == 'assemble'):
 	assemble(username)
+elif (event == 'fulfill'):
+	fulfill(username)
 
 
 

--- a/inventory_event.py
+++ b/inventory_event.py
@@ -73,7 +73,7 @@ def record_fulfill(user):
 
 def store_event(user):
 	f = open('/home/pi/ops_tools/data/stored_inventory_events.csv','a')
-	f.write('%d,%d,%d' % (event, timestamp, user))
+	f.write('%s,%s,%s' % (event, timestamp, user))
 	f.close()
 
 store_event(username)

--- a/inventory_event.py
+++ b/inventory_event.py
@@ -17,10 +17,12 @@ from oauth2client.service_account import ServiceAccountCredentials
 
 if (len(sys.argv) == 3):
 	print 'three'
-	username = sys.argv[3]
+	username = sys.argv[2]
+	print username
 elif (len(sys.argv) == 2):
 	print 'two'
 	username = os.getusername()
+	print username
 else:
 	print 'ERROR - wrong number of arguments.'
 	print 'Usage: $ inventory_event.py <event> <username>'

--- a/inventory_event.py
+++ b/inventory_event.py
@@ -50,13 +50,16 @@ spreadsheet = c.open('PR9450 Part Usage')
 
 def assemble(username):
 	PCB = spreadsheet.worksheet("PR9027")
-	PCB.append_row([])
+	PCB.append_row(["radio_assemble", timestamp, username])
+
+if (event == 'assemble'):
+	assemble(username)
 
 
 
 
-worksheet = spreadsheet.worksheet("PR9027") 
-print worksheet
-
-print worksheet.acell('A2').value
-worksheet.append_row(["A", "B", "C"])
+#worksheet = spreadsheet.worksheet("PR9027") 
+#print worksheet
+#
+#print worksheet.acell('A2').value
+#worksheet.append_row(["A", "B", "C"])

--- a/inventory_event.py
+++ b/inventory_event.py
@@ -15,10 +15,10 @@ import os
 import sys
 from oauth2client.service_account import ServiceAccountCredentials
 
-if (len(sys.argv) == '3'):
+if (len(sys.argv) == '4'):
 	print 'three'
-	username = sys.argv[3]
-elif (len(sys.argv) == '2'):
+	username = sys.argv[4]
+elif (len(sys.argv) == '3'):
 	print 'two'
 	username = os.getusername()
 else:

--- a/inventory_event.py
+++ b/inventory_event.py
@@ -21,13 +21,13 @@ if (len(sys.argv) == 3):
 	print username
 elif (len(sys.argv) == 2):
 	print 'two'
-	username = os.getusername()
+	username = os.getlogin()
 	print username
 else:
 	print 'ERROR - wrong number of arguments.'
 	print 'Usage: $ inventory_event.py <event> <username>'
 
-print username
+#print username
 
 scope = ['https://spreadsheets.google.com/feeds']
 

--- a/inventory_event.py
+++ b/inventory_event.py
@@ -37,10 +37,10 @@ if event not in events:
 timestamp = datetime.datetime.now().isoformat()
 print 'time is', timestamp
 
-scope = ['https://spreadsheets.google.com/feeds']
-credentials = ServiceAccountCredentials.from_json_keyfile_name('/home/pi/tpr-inv.json', scope)
-c = gspread.authorize(credentials)
-spreadsheet = c.open('PR9450 Part Usage')
+#scope = ['https://spreadsheets.google.com/feeds']
+#credentials = ServiceAccountCredentials.from_json_keyfile_name('/home/pi/tpr-inv.json', scope)
+#c = gspread.authorize(credentials)
+#spreadsheet = c.open('PR9450 Part Usage')
 
 
 # NOTE: This function takes a long time (~20s) to run. This is not practical for on-the-fly use,

--- a/inventory_event.py
+++ b/inventory_event.py
@@ -73,7 +73,7 @@ def record_fulfill(user):
 
 def store_event(user):
 	f = open('/home/pi/ops_tools/data/stored_inventory_events.csv','a')
-	f.write('%d,%d,%d' % event timestamp user)
+	f.write('%d,%d,%d' % (event, timestamp, user)
 	f.close()
 
 store_event(username)

--- a/inventory_event.py
+++ b/inventory_event.py
@@ -55,11 +55,11 @@ def assemble(user):
 
 def fulfill(user):
 	antenna = spreadsheet.worksheet("PR2034")
-	antenna.append_row(["radio_assemble", timestamp, "-1", user])
+	antenna.append_row(["radio_fulfill", timestamp, "-1", user])
 	box = spreadsheet.worksheet("PR2500")
-	box.append_row(["radio_assemble", timestamp, "-1", user])
+	box.append_row(["radio_fulfill", timestamp, "-1", user])
 	jar = spreadsheet.worksheet("PR1016")
-	jar.append_row(["radio_assemble", timestamp, "-1", user])
+	jar.append_row(["radio_fulfill", timestamp, "-1", user])
 
 if (event == 'assemble'):
 	assemble(username)

--- a/inventory_event.py
+++ b/inventory_event.py
@@ -76,6 +76,7 @@ def store_event(user):
 	f.close()
 
 store_event(username)
+sys.exit(0)
 
 #if (event == 'assemble'):
 #	store_assemble(username)

--- a/inventory_event.py
+++ b/inventory_event.py
@@ -71,8 +71,8 @@ def record_fulfill(user):
 
 
 def store_event(user):
-	f = open('/home/pi/ops_tools/data/stored_inventory_events.csv','w')
-	f.write(event,timestamp,user'\n')
+	f = open('/home/pi/ops_tools/data/stored_inventory_events.csv','a')
+	f.write(event,timestamp,user)
 	f.close()
 
 store_event(username)

--- a/inventory_event.py
+++ b/inventory_event.py
@@ -21,7 +21,7 @@ if (len(sys.argv) == 3):
 	print username
 elif (len(sys.argv) == 2):
 	print 'two'
-	username = os.getlogin()
+	username = os.uname()[1]
 	print username
 else:
 	print 'ERROR - wrong number of arguments.'

--- a/inventory_event.py
+++ b/inventory_event.py
@@ -73,7 +73,7 @@ def record_fulfill(user):
 
 def store_event(user):
 	f = open('/home/pi/ops_tools/data/stored_inventory_events.csv','a')
-	f.write('%d,%d,%d' % (event, timestamp, user)
+	f.write('%d,%d,%d' % (event, timestamp, user))
 	f.close()
 
 store_event(username)

--- a/inventory_event.py
+++ b/inventory_event.py
@@ -33,22 +33,30 @@ else:
 events = ['assemble', 'fulfill']
 event = sys.argv[1]
 
+# Confirm that the user wants to do a valid operation.
 if event not in events:
 	print 'ERROR - invalid event.'
 	print 'Use `assemble` or `fulfill`.'
 	sys.exit(1)
-	
+
+timestamp = time.time()
+print timestamp
 
 scope = ['https://spreadsheets.google.com/feeds']
 credentials = ServiceAccountCredentials.from_json_keyfile_name('/home/pi/tpr-inv.json', scope)
-
-
 c = gspread.authorize(credentials)
 spreadsheet = c.open('PR9450 Part Usage')
+
+
+def assemble(username):
+	PCB = spreadsheet.worksheet("PR9027")
+	PCB.append_row([])
+
+
+
 
 worksheet = spreadsheet.worksheet("PR9027") 
 print worksheet
 
 print worksheet.acell('A2').value
-row_to_add = ['foo', 'foo', 'three']
 worksheet.append_row(["A", "B", "C"])

--- a/inventory_event.py
+++ b/inventory_event.py
@@ -18,7 +18,7 @@ if (len(sys.argv) == '3'):
 	username = sys.argv[3]
 elif (len(sys.argv) == '2'):
 	username = os.getusername()
-else
+else:
 	print 'ERROR - wrong number of arguments.'
 	print 'Usage: $ inventory_event.py <event> <username>'
 

--- a/inventory_event.py
+++ b/inventory_event.py
@@ -16,8 +16,10 @@ import sys
 from oauth2client.service_account import ServiceAccountCredentials
 
 if (len(sys.argv) == '3'):
+	print 'three'
 	username = sys.argv[3]
 elif (len(sys.argv) == '2'):
+	print 'two'
 	username = os.getusername()
 else:
 	print 'ERROR - wrong number of arguments.'

--- a/inventory_event.py
+++ b/inventory_event.py
@@ -52,6 +52,8 @@ def assemble(user):
 	screw.append_row(["radio_assemble", timestamp, "-4", user])	
 	knob = spreadsheet.worksheet("PR2036")
 	knob.append_row(["radio_assemble", timestamp, "-1", user])
+	mech_assy = spreadsheet.worksheet("PR2040")
+	mech_assy.append_row(["radio_assemble", timestamp, "+1", user])
 
 def fulfill(user):
 	antenna = spreadsheet.worksheet("PR2034")
@@ -60,6 +62,8 @@ def fulfill(user):
 	box.append_row(["radio_fulfill", timestamp, "-1", user])
 	jar = spreadsheet.worksheet("PR1016")
 	jar.append_row(["radio_fulfill", timestamp, "-1", user])
+	mech_assy = spreadsheet.worksheet("PR2040")
+	mech_assy.append_row(["radio_assemble", timestamp, "-1", user])
 
 if (event == 'assemble'):
 	assemble(username)

--- a/inventory_event.py
+++ b/inventory_event.py
@@ -15,10 +15,10 @@ import os
 import sys
 from oauth2client.service_account import ServiceAccountCredentials
 
-if (len(sys.argv) == 4):
+if (len(sys.argv) == 3):
 	print 'three'
-	username = sys.argv[4]
-elif (len(sys.argv) == 3):
+	username = sys.argv[3]
+elif (len(sys.argv) == 2):
 	print 'two'
 	username = os.getusername()
 else:

--- a/inventory_event.py
+++ b/inventory_event.py
@@ -1,7 +1,28 @@
 #!/usr/bin/env python
 
+# This script records inventory events (creation of mechanically assembled radios,
+# removal of mechanical components from inventory stores) in The Public Radio's
+# inventory management spreadsheet on Google Sheets.
+#
+# It takes in:
+#	* Operation (mechanical assembly created OR order fulfilled)
+#	* Username (just a string)
+
+
 import gspread
+import time
+import os
 from oauth2client.service_account import ServiceAccountCredentials
+
+if (len(sys.argv) == '3'):
+	username = sys.argv[3]
+elif (len(sys.argv) == '2'):
+	username = os.getusername()
+else
+	print 'ERROR - wrong number of arguments.'
+	print 'Usage: $ inventory_event.py <event> <username>'
+
+print username
 
 scope = ['https://spreadsheets.google.com/feeds']
 
@@ -10,10 +31,10 @@ credentials = ServiceAccountCredentials.from_json_keyfile_name('/home/pi/tpr-inv
 
 c = gspread.authorize(credentials)
 spreadsheet = c.open('PR9450 Part Usage')
-print(spreadsheet)
+print spreadsheet
 worksheet = spreadsheet.worksheet("PR9027") 
-print(worksheet)
+print worksheet
 
-print(worksheet.acell('A2').value)
+print worksheet.acell('A2').value
 row_to_add = ['foo', 'foo', 'three']
 worksheet.append_row(["A", "B", "C"])

--- a/inventory_event.py
+++ b/inventory_event.py
@@ -15,10 +15,10 @@ import os
 import sys
 from oauth2client.service_account import ServiceAccountCredentials
 
-if (len(sys.argv) == '4'):
+if (len(sys.argv) == 4):
 	print 'three'
 	username = sys.argv[4]
-elif (len(sys.argv) == '3'):
+elif (len(sys.argv) == 3):
 	print 'two'
 	username = os.getusername()
 else:

--- a/inventory_event.py
+++ b/inventory_event.py
@@ -35,7 +35,7 @@ if event not in events:
 	sys.exit(1)
 
 timestamp = datetime.datetime.now().isoformat()
-print 'time is' timestamp
+print 'time is', timestamp
 
 scope = ['https://spreadsheets.google.com/feeds']
 credentials = ServiceAccountCredentials.from_json_keyfile_name('/home/pi/tpr-inv.json', scope)

--- a/inventory_event.py
+++ b/inventory_event.py
@@ -73,7 +73,7 @@ def record_fulfill(user):
 
 def store_event(user):
 	f = open('/home/pi/ops_tools/data/stored_inventory_events.csv','a')
-	f.write('%s,%s,%s' % (event, timestamp, user))
+	f.write('%s,%s,%s\n' % (event, timestamp, user))
 	f.close()
 
 store_event(username)

--- a/inventory_event.py
+++ b/inventory_event.py
@@ -15,6 +15,8 @@ import os
 import sys
 from oauth2client.service_account import ServiceAccountCredentials
 
+# Set username. Ideally the username is always set to be a person's name (or similar),
+# but in the cases where it's not set then the Raspberry Pi's $HOSTNAME will suffice.
 if (len(sys.argv) == 3):
 	print 'three'
 	username = sys.argv[2]
@@ -26,17 +28,24 @@ elif (len(sys.argv) == 2):
 else:
 	print 'ERROR - wrong number of arguments.'
 	print 'Usage: $ inventory_event.py <event> <username>'
+	sys.exit(1)
 
-#print username
+events = ['assemble', 'fulfill']
+event = sys.argv[1]
+
+if event not in events:
+	print 'ERROR - invalid event.'
+	print 'Use `assemble` or `fulfill`.'
+	sys.exit(1)
+	
 
 scope = ['https://spreadsheets.google.com/feeds']
-
 credentials = ServiceAccountCredentials.from_json_keyfile_name('/home/pi/tpr-inv.json', scope)
 
 
 c = gspread.authorize(credentials)
 spreadsheet = c.open('PR9450 Part Usage')
-print spreadsheet
+
 worksheet = spreadsheet.worksheet("PR9027") 
 print worksheet
 

--- a/inventory_event.py
+++ b/inventory_event.py
@@ -43,7 +43,9 @@ c = gspread.authorize(credentials)
 spreadsheet = c.open('PR9450 Part Usage')
 
 
-def assemble(user):
+# NOTE: This function takes a long time (~20s) to run. This is not practical for on-the-fly use,
+# so this function is NOT currently being used.
+def record_assemble(user):
 	PCB = spreadsheet.worksheet("PR9027")
 	PCB.append_row(["radio_assemble", timestamp, "-1", user])
 	lid = spreadsheet.worksheet("PR1014")
@@ -55,7 +57,9 @@ def assemble(user):
 	mech_assy = spreadsheet.worksheet("PR2040")
 	mech_assy.append_row(["radio_assemble", timestamp, "+1", user])
 
-def fulfill(user):
+# NOTE: This function takes a long time (~20s) to run. This is not practical for on-the-fly use,
+# so this function is NOT currently being used.
+def record_fulfill(user):
 	antenna = spreadsheet.worksheet("PR2034")
 	antenna.append_row(["radio_fulfill", timestamp, "-1", user])
 	box = spreadsheet.worksheet("PR2500")
@@ -65,10 +69,18 @@ def fulfill(user):
 	mech_assy = spreadsheet.worksheet("PR2040")
 	mech_assy.append_row(["radio_assemble", timestamp, "-1", user])
 
-if (event == 'assemble'):
-	assemble(username)
-elif (event == 'fulfill'):
-	fulfill(username)
+
+def store_event(user):
+	f = open('/home/pi/ops_tools/data/stored_inventory_events.csv','w')
+	f.write(event','timestamp','user'\n')
+	f.close()
+
+store_event(username)
+
+#if (event == 'assemble'):
+#	store_assemble(username)
+#elif (event == 'fulfill'):
+#	store_fulfill(username)
 
 
 

--- a/inventory_event.py
+++ b/inventory_event.py
@@ -12,6 +12,7 @@ import gspread
 import datetime
 from os import uname
 import sys
+import csv
 from oauth2client.service_account import ServiceAccountCredentials
 
 # Set username. Ideally the username is always set to be a person's name (or similar),
@@ -72,7 +73,7 @@ def record_fulfill(user):
 
 def store_event(user):
 	f = open('/home/pi/ops_tools/data/stored_inventory_events.csv','a')
-	f.write(event,timestamp,user)
+	f.write('%d,%d,%d' % event timestamp user)
 	f.close()
 
 store_event(username)

--- a/inventory_event.py
+++ b/inventory_event.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python
+
+import gspread
+from oauth2client.service_account import ServiceAccountCredentials
+
+scope = ['https://spreadsheets.google.com/feeds']
+
+credentials = ServiceAccountCredentials.from_json_keyfile_name('/home/pi/tpr-inv.json', scope)
+
+
+c = gspread.authorize(credentials)
+spreadsheet = c.open('PR9450 Part Usage')
+print(spreadsheet)
+worksheet = spreadsheet.worksheet("PR9027") 
+print(worksheet)
+
+print(worksheet.acell('A2').value)
+row_to_add = ['foo', 'foo', 'three']
+worksheet.append_row(["A", "B", "C"])

--- a/inventory_event.py
+++ b/inventory_event.py
@@ -30,7 +30,7 @@ event = sys.argv[1]
 
 # Confirm that the user wants to do a valid operation.
 if event not in events:
-	print 'ERROR - invalid event.'
+	print 'ERROR - invalid event:', event
 	print 'Use `assemble` or `fulfill`.'
 	sys.exit(1)
 

--- a/inventory_event.py
+++ b/inventory_event.py
@@ -8,12 +8,11 @@
 #	* Operation (mechanical assembly created OR order fulfilled)
 #	* Username (just a string)
 
-import gspread
+#import gspread
 import datetime
 from os import uname
 import sys
-import csv
-from oauth2client.service_account import ServiceAccountCredentials
+#from oauth2client.service_account import ServiceAccountCredentials
 
 # Set username. Ideally the username is always set to be a person's name (or similar),
 # but in the cases where it's not set then the Raspberry Pi's $HOSTNAME will suffice.
@@ -46,29 +45,29 @@ spreadsheet = c.open('PR9450 Part Usage')
 
 # NOTE: This function takes a long time (~20s) to run. This is not practical for on-the-fly use,
 # so this function is NOT currently being used.
-def record_assemble(user):
-	PCB = spreadsheet.worksheet("PR9027")
-	PCB.append_row(["radio_assemble", timestamp, "-1", user])
-	lid = spreadsheet.worksheet("PR1014")
-	lid.append_row(["radio_assemble", timestamp, "-1", user])
-	screw = spreadsheet.worksheet("PR2039")
-	screw.append_row(["radio_assemble", timestamp, "-4", user])	
-	knob = spreadsheet.worksheet("PR2036")
-	knob.append_row(["radio_assemble", timestamp, "-1", user])
-	mech_assy = spreadsheet.worksheet("PR2040")
-	mech_assy.append_row(["radio_assemble", timestamp, "+1", user])
+#def record_assemble(user):
+#	PCB = spreadsheet.worksheet("PR9027")
+#	PCB.append_row(["radio_assemble", timestamp, "-1", user])
+#	lid = spreadsheet.worksheet("PR1014")
+#	lid.append_row(["radio_assemble", timestamp, "-1", user])
+#	screw = spreadsheet.worksheet("PR2039")
+#	screw.append_row(["radio_assemble", timestamp, "-4", user])	
+#	knob = spreadsheet.worksheet("PR2036")
+#	knob.append_row(["radio_assemble", timestamp, "-1", user])
+#	mech_assy = spreadsheet.worksheet("PR2040")
+#	mech_assy.append_row(["radio_assemble", timestamp, "+1", user])
 
 # NOTE: This function takes a long time (~20s) to run. This is not practical for on-the-fly use,
 # so this function is NOT currently being used.
-def record_fulfill(user):
-	antenna = spreadsheet.worksheet("PR2034")
-	antenna.append_row(["radio_fulfill", timestamp, "-1", user])
-	box = spreadsheet.worksheet("PR2500")
-	box.append_row(["radio_fulfill", timestamp, "-1", user])
-	jar = spreadsheet.worksheet("PR1016")
-	jar.append_row(["radio_fulfill", timestamp, "-1", user])
-	mech_assy = spreadsheet.worksheet("PR2040")
-	mech_assy.append_row(["radio_assemble", timestamp, "-1", user])
+#def record_fulfill(user):
+#	antenna = spreadsheet.worksheet("PR2034")
+#	antenna.append_row(["radio_fulfill", timestamp, "-1", user])
+#	box = spreadsheet.worksheet("PR2500")
+#	box.append_row(["radio_fulfill", timestamp, "-1", user])
+#	jar = spreadsheet.worksheet("PR1016")
+#	jar.append_row(["radio_fulfill", timestamp, "-1", user])
+#	mech_assy = spreadsheet.worksheet("PR2040")
+#	mech_assy.append_row(["radio_assemble", timestamp, "-1", user])
 
 
 def store_event(user):

--- a/inventory_event.py
+++ b/inventory_event.py
@@ -8,10 +8,9 @@
 #	* Operation (mechanical assembly created OR order fulfilled)
 #	* Username (just a string)
 
-
 import gspread
 import datetime
-import os
+from os import uname
 import sys
 from oauth2client.service_account import ServiceAccountCredentials
 

--- a/quickstart.py
+++ b/quickstart.py
@@ -1,0 +1,82 @@
+
+from __future__ import print_function
+import httplib2
+import os
+
+from apiclient import discovery
+from oauth2client import client
+from oauth2client import tools
+from oauth2client.file import Storage
+
+try:
+    import argparse
+    flags = argparse.ArgumentParser(parents=[tools.argparser]).parse_args()
+except ImportError:
+    flags = None
+
+# If modifying these scopes, delete your previously saved credentials
+# at ~/.credentials/sheets.googleapis.com-python-quickstart.json
+SCOPES = 'https://www.googleapis.com/auth/spreadsheets.readonly'
+CLIENT_SECRET_FILE = 'client_secret.json'
+APPLICATION_NAME = 'Google Sheets API Python Quickstart'
+
+
+def get_credentials():
+    """Gets valid user credentials from storage.
+
+    If nothing has been stored, or if the stored credentials are invalid,
+    the OAuth2 flow is completed to obtain the new credentials.
+
+    Returns:
+        Credentials, the obtained credential.
+    """
+    home_dir = os.path.expanduser('~')
+    credential_dir = os.path.join(home_dir, '.credentials')
+    if not os.path.exists(credential_dir):
+        os.makedirs(credential_dir)
+    credential_path = os.path.join(credential_dir,
+                                   'sheets.googleapis.com-python-quickstart.json')
+
+    store = Storage(credential_path)
+    credentials = store.get()
+    if not credentials or credentials.invalid:
+        flow = client.flow_from_clientsecrets(CLIENT_SECRET_FILE, SCOPES)
+        flow.user_agent = APPLICATION_NAME
+        if flags:
+            credentials = tools.run_flow(flow, store, flags)
+        else: # Needed only for compatibility with Python 2.6
+            credentials = tools.run(flow, store)
+        print('Storing credentials to ' + credential_path)
+    return credentials
+
+def main():
+    """Shows basic usage of the Sheets API.
+
+    Creates a Sheets API service object and prints the names and majors of
+    students in a sample spreadsheet:
+    https://docs.google.com/spreadsheets/d/1BxiMVs0XRA5nFMdKvBdBZjgmUUqptlbs74OgvE2upms/edit
+    """
+    credentials = get_credentials()
+    http = credentials.authorize(httplib2.Http())
+    discoveryUrl = ('https://sheets.googleapis.com/$discovery/rest?'
+                    'version=v4')
+    service = discovery.build('sheets', 'v4', http=http,
+                              discoveryServiceUrl=discoveryUrl)
+
+    spreadsheetId = '1BxiMVs0XRA5nFMdKvBdBZjgmUUqptlbs74OgvE2upms'
+    rangeName = 'Class Data!A2:E'
+    result = service.spreadsheets().values().get(
+        spreadsheetId=spreadsheetId, range=rangeName).execute()
+    values = result.get('values', [])
+
+    if not values:
+        print('No data found.')
+    else:
+        print('Name, Major:')
+        for row in values:
+            # Print columns A and E, which correspond to indices 0 and 4.
+            print('%s, %s' % (row[0], row[4]))
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
so this didn’t go exactly as planned, as the process of sending data to Google Sheets is kind of painfully slow. But, i’m now storing inventory events in a csv file (untracked by git) in the data folder. next step is just to write a process that’ll parse that csv file and update google sheets, and then set up a cron task to run that process at like three in the morning. anyway, this is a move in the right direction - if a bit more laggy than i had hoped.