### PR TITLE
Print label exit code

### DIFF
--- a/print_label.sh
+++ b/print_label.sh
@@ -93,8 +93,8 @@ if [[ $? -ne 0 ]]; then
 fi
 
 # Update radio in tpr-coordinator
-echo "Updating shipment_id $id in the order database"
-curl -X PUT $url/shipments/$id -H "$headers" -H 'Content-Type: application/json' -d '{"shipment": {"shipment_status": "label_printed"}}' > /dev/null 2>&1
+#echo "Updating shipment_id $id in the order database"
+#curl -X PUT $url/shipments/$id -H "$headers" -H 'Content-Type: application/json' -d '{"shipment": {"shipment_status": "label_printed"}}' > /dev/null 2>&1
 
 clean_up
 echo 'All new labels sent to print ✅'

--- a/print_label.sh
+++ b/print_label.sh
@@ -94,8 +94,8 @@ if [[ $? -ne 0 ]]; then
 fi
 
 # Update radio in tpr-coordinator
-#echo "Updating shipment_id $id in the order database"
-#curl -X PUT $url/shipments/$id -H "$headers" -H 'Content-Type: application/json' -d '{"shipment": {"shipment_status": "label_printed"}}' > /dev/null 2>&1
+echo "Updating shipment_id $id in the order database"
+curl -X PUT $url/shipments/$id -H "$headers" -H 'Content-Type: application/json' -d '{"shipment": {"shipment_status": "label_printed"}}' > /dev/null 2>&1
 
 clean_up
 echo 'All new labels sent to print ✅'

--- a/print_label.sh
+++ b/print_label.sh
@@ -78,7 +78,7 @@ if [ -n "$id" ];	then
 else 
 	echo "No labels in the database!"
 	clean_up
-	exit
+	exit 3
 fi
 
 

--- a/print_label.sh
+++ b/print_label.sh
@@ -67,6 +67,7 @@ label_url=$(echo -n $next_shipment_to_print | jq -r '.label_url' | tr -d '\n')
 id=$(echo -n $next_shipment_to_print | jq '.id')
 
 echo '----------------'
+echo "id is" $id
 
 # if $id isn't null, download it and then confirm.
 if [ -n "$id" ];	then 

--- a/print_label.sh
+++ b/print_label.sh
@@ -70,7 +70,7 @@ echo '----------------'
 echo "id is" $id
 
 # if $id isn't null, download it and then confirm.
-if [ -n "$id" ];	then 
+if [ "$id" != "null" ];	then 
 	# Download label from label_url
 	curl "$label_url" > ./$id.pdf;
 	# echo -n $label_data | base64 --decode > ./$id.pdf;


### PR DESCRIPTION
this adds an exit code of 3 if the database has no labels to print. an exit code of 1 is still provided if the print command fails.

note that working on this uncovered an issue that’s been in the code for… forever - that the coordinator actually returns the string “null” rather than a null response. hence the changes on ~line 73.